### PR TITLE
ruamel.yaml upgrade to >0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache/
 
 # C extensions
 *.so

--- a/pypyraws/steps/s3fetchyaml.py
+++ b/pypyraws/steps/s3fetchyaml.py
@@ -25,7 +25,8 @@ def run_step(context):
     logger.debug("started")
     response = pypyraws.aws.s3.get_payload(context)
 
-    payload = yaml.safe_load(response)
+    yaml_loader = yaml.YAML(typ='safe', pure=True)
+    payload = yaml_loader.load(response)
     logger.debug("successfully parsed yaml from s3 response bytes")
     context.update(payload)
     logger.info("loaded s3 yaml into pypyr context")

--- a/pypyraws/version.py
+++ b/pypyraws/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.0.4'
+__version__ = '0.1.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.4
+current_version = 0.1.0
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pypyr', 'boto3', 'ruamel.yaml<0.15'],
+    install_requires=['pypyr', 'boto3', 'ruamel.yaml'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/unit/pypyraws/steps/s3fetchyaml_test.py
+++ b/tests/unit/pypyraws/steps/s3fetchyaml_test.py
@@ -1,4 +1,5 @@
 """s3fetchyaml.py unit tests."""
+import io
 import pypyraws.steps.s3fetchyaml  # as s3fetchyaml
 from pypyr.context import Context
 import ruamel.yaml as yaml
@@ -9,9 +10,10 @@ from unittest.mock import patch
 def test_s3fetchyaml(mock_s3):
     """Success path all the way through to the mocked boto s3 object."""
     input_dict = {'newkey': 'newvalue', 'newkey2': 'newvalue2'}
-    string_of_yaml = yaml.dump(input_dict, Dumper=yaml.RoundTripDumper)
-    bunch_of_bytes = bytes(string_of_yaml, 'utf-8')
-    mock_s3.side_effect = [{'Body': bunch_of_bytes}]
+    yaml_loader = yaml.YAML()
+    string_stream = io.StringIO()
+    yaml_loader.dump(input_dict, string_stream)
+    mock_s3.side_effect = [{'Body': string_stream.getvalue()}]
 
     context = Context({
         'k1': 'v1',


### PR DESCRIPTION
- upgrade version for new pypi release
- update ruamel.yaml to >0.15. This is a major, interface breaking change on the part of ruamel. pypyr consumers are not affected, however.
- .pytest_cache to gitignore