### PR TITLE
remove legacy pypi url from deploy script

### DIFF
--- a/ops/shippable-pypi-release.sh
+++ b/ops/shippable-pypi-release.sh
@@ -20,7 +20,7 @@ pip uninstall -y pypyraws
 python setup.py bdist_wheel
 
 # Deploy wheel
-twine upload --repository-url ${PYPI_URL} --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyraws-${NEW_VERSION}-py3-none-any.whl
+twine upload --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyraws-${NEW_VERSION}-py3-none-any.whl
 
 echo "----------Done with twine upload-------------------------------------"
 


### PR DESCRIPTION
- remove legacy repository url from deploy script to pypi