### PR TITLE
Bump version: 0.1.0 → 0.1.1

### DIFF
--- a/pypyraws/version.py
+++ b/pypyraws/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 
 [bdist_wheel]
 universal = 0


### PR DESCRIPTION
- No functional change. Just version bump to ensure deploy consistency because of previous pypi deploy errs.