### PR TITLE
unit test only: cater for new str formatting syntax

### DIFF
--- a/tests/unit/pypyraws/steps/waitfor_test.py
+++ b/tests/unit/pypyraws/steps/waitfor_test.py
@@ -828,7 +828,7 @@ def test_get_poll_args_substitutions():
      error_on_wait_timeout) = waitfor_step.get_poll_args(waitfor_dict, context)
 
     assert wait_for_field == 'field name'
-    assert to_be == '123.4'
+    assert to_be == 123.4
     assert poll_interval == 99
     assert max_attempts == 66
     assert not error_on_wait_timeout


### PR DESCRIPTION
- unit test accounts for new format string syntax where source type is maintained and not converted to string by default