### PR TITLE
python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -568,24 +568,24 @@ Day-to-day testing
 
     pytest tests/unit/arb_test_file.py
 
+*****
+Help!
+*****
+Don't Panic! For help, community or talk, join the chat on |discord|!
+
 **********
 Contribute
 **********
+Developers
+==========
+For information on how to help with pypyr, run tests and coverage, please do
+check out the `contribution guide <https://github.com/pypyr/pypyr-cli/blob/master/CONTRIBUTING.rst>`_.
+
 Bugs
 ====
 Well, you know. No one's perfect. Feel free to `create an issue
 <https://github.com/pypyr/pypyr-aws/issues/new>`_.
 
-Contribute to the pypyr project
-===============================
-The usual jazz - create an issue, fork, code, test, PR. It might be an idea to
-discuss your idea via the Issues list first before you go off and write a
-huge amount of code - you never know, something might already be in the works,
-or maybe it's not quite right for this plug-in (you're still welcome to fork
-and go wild regardless, of course, it just mightn't get merged back in here).
-
-Get in touch anyway, would love to hear from you at
-https://www.345.systems/contact.
 
 .. |build-status| image:: https://api.shippable.com/projects/58efdfe130eb380700e559a4/badge?branch=master
                     :alt: build status
@@ -599,3 +599,5 @@ https://www.345.systems/contact.
                 :alt: pypi version
                 :target: https://pypi.python.org/pypi/pypyraws/
                 :align: bottom
+
+.. |discord| replace:: `discord <https://discordapp.com/invite/8353JkB>`__

--- a/pypyraws/steps/waitfor.py
+++ b/pypyraws/steps/waitfor.py
@@ -106,9 +106,10 @@ def run_step(context):
                               f"return {to_be} within {max_attempts} retries.")
         else:
             context['awsWaitForTimedOut'] = True
-            logger.warn(f"aws {service_name} {method_name} did NOT return "
-                        f" {to_be}. errorOnWaitTimeout is False, so pipeline "
-                        "will proceed to the next step anyway.")
+            logger.warning(
+                f"aws {service_name} {method_name} did NOT return "
+                f" {to_be}. errorOnWaitTimeout is False, so pipeline "
+                "will proceed to the next step anyway.")
 
     logger.debug("done")
 

--- a/shippable.yaml
+++ b/shippable.yaml
@@ -2,6 +2,7 @@ language: python
 
 python:
  - "3.6"
+ - "3.7"
 
 build:
   ci:

--- a/tests/unit/pypyraws/aws/s3_test.py
+++ b/tests/unit/pypyraws/aws/s3_test.py
@@ -14,9 +14,7 @@ def test_get_payload_no_s3fetch():
     with pytest.raises(KeyNotInContextError) as err_info:
         ps3.get_payload(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'s3Fetch not found in the pypyr "
-        "context.',)")
+    assert str(err_info.value) == ("s3Fetch not found in the pypyr context.")
 
 
 def test_get_payload_no_methodargs():
@@ -25,9 +23,8 @@ def test_get_payload_no_methodargs():
     with pytest.raises(KeyNotInContextError) as err_info:
         ps3.get_payload(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'s3Fetch missing required key for "
-        "pypyraws.steps.s3fetch step: methodArgs',)")
+    assert str(err_info.value) == ("s3Fetch missing required key for "
+                                   "pypyraws.steps.s3fetch step: methodArgs")
 
 
 @patch('pypyraws.aws.service.operation_exec')

--- a/tests/unit/pypyraws/aws/service_test.py
+++ b/tests/unit/pypyraws/aws/service_test.py
@@ -51,8 +51,7 @@ def test_op_exec_method_doesnt_exist(mock_boto):
                             method_name='arbmethod',
                             operation_args={'k1': 'v1', 'k2': 'v2'})
 
-    assert repr(err_info.value) == (
-        "AttributeError(\"Mock object has no attribute 'arbmethod'\",)")
+    assert str(err_info.value) == "Mock object has no attribute 'arbmethod'"
 
 # ---------------------------- operation_exec --------------------------------#
 

--- a/tests/unit/pypyraws/contextargs_test.py
+++ b/tests/unit/pypyraws/contextargs_test.py
@@ -36,9 +36,7 @@ def test_get_awsclient_args_missing_awsclientin():
         client_in, service_name, method_name = contextargs.get_awsclient_args(
             context, 'pypyraws.steps.client')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'awsClientIn not found in the pypyr "
-        "context.',)")
+    assert str(err_info.value) == "awsClientIn not found in the pypyr context."
 
 
 def test_get_awsclient_args_missing_servicename():
@@ -54,9 +52,8 @@ def test_get_awsclient_args_missing_servicename():
         client_in, service_name, method_name = contextargs.get_awsclient_args(
             context, 'pypyraws.steps.client')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"awsClientIn missing required key for "
-        "pypyraws.steps.client: 'serviceName'\",)")
+    assert str(err_info.value) == ("awsClientIn missing required key for "
+                                   "pypyraws.steps.client: 'serviceName'")
 
 
 def test_get_awsclient_args_missing_methodname():
@@ -72,9 +69,8 @@ def test_get_awsclient_args_missing_methodname():
         client_in, service_name, method_name = contextargs.get_awsclient_args(
             context, 'pypyraws.steps.client')
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"awsClientIn missing required key for "
-        "pypyraws.steps.client: 'methodName'\",)")
+    assert str(err_info.value) == ("awsClientIn missing required key for "
+                                   "pypyraws.steps.client: 'methodName'")
 
 
 def test_get_awsclient_args_servicename_empty():
@@ -91,9 +87,8 @@ def test_get_awsclient_args_servicename_empty():
         client_in, service_name, method_name = contextargs.get_awsclient_args(
             context, 'pypyraws.steps.client')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError('serviceName required in awsClientIn "
-        "for pypyraws.steps.client',)")
+    assert str(err_info.value) == ("serviceName required in awsClientIn "
+                                   "for pypyraws.steps.client")
 
 
 def test_get_awsclient_args_methodname_empty():
@@ -110,9 +105,8 @@ def test_get_awsclient_args_methodname_empty():
         client_in, service_name, method_name = contextargs.get_awsclient_args(
             context, 'pypyraws.steps.client')
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError('methodName required in awsClientIn "
-        "for pypyraws.steps.client',)")
+    assert str(err_info.value) == ("methodName required in awsClientIn "
+                                   "for pypyraws.steps.client")
 
 # ---------------------------- get_awsclient_args-----------------------------#
 

--- a/tests/unit/pypyraws/errors_test.py
+++ b/tests/unit/pypyraws/errors_test.py
@@ -11,8 +11,7 @@ def test_base_error_raises():
     with pytest.raises(PypyrAwsError) as err_info:
         raise PypyrAwsError("this is error text right here")
 
-    assert repr(err_info.value) == ("Error('this is error text "
-                                    "right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_wait_timeout_raises():
@@ -20,8 +19,7 @@ def test_wait_timeout_raises():
     with pytest.raises(WaitTimeOut) as err_info:
         raise WaitTimeOut("this is error text right here")
 
-    assert repr(err_info.value) == ("WaitTimeOut('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_wait_timeout_inheritance():

--- a/tests/unit/pypyraws/steps/client_test.py
+++ b/tests/unit/pypyraws/steps/client_test.py
@@ -15,9 +15,7 @@ def test_aws_client_missing_awsclientin():
     with pytest.raises(KeyNotInContextError) as err_info:
         client_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'awsClientIn not found in the pypyr "
-        "context.',)")
+    assert str(err_info.value) == "awsClientIn not found in the pypyr context."
 
 
 @patch('pypyraws.aws.service.operation_exec', return_value={'rk1': 'rv1',

--- a/tests/unit/pypyraws/steps/ecswaitprep_test.py
+++ b/tests/unit/pypyraws/steps/ecswaitprep_test.py
@@ -11,9 +11,8 @@ def test_waitprep_awsclientout_missing():
         context = Context({'blah': 'blah blah'})
         prepstep.run_step(context)
 
-    assert repr(err.value) == (
-        "KeyNotInContextError(\"context['awsClientOut'] doesn't exist. It "
-        "must exist for pypyraws.steps.ecswaitprep.\",)")
+    assert str(err.value) == ("context['awsClientOut'] doesn't exist. It "
+                              "must exist for pypyraws.steps.ecswaitprep.")
 
 
 def test_waitprep_awsclientout_empty():
@@ -22,9 +21,8 @@ def test_waitprep_awsclientout_empty():
         context = Context({'awsClientOut': None})
         prepstep.run_step(context)
 
-    assert repr(err.value) == (
-        "KeyInContextHasNoValueError(\"context['awsClientOut'] must have a "
-        "value for pypyraws.steps.ecswaitprep.\",)")
+    assert str(err.value) == ("context['awsClientOut'] must have a "
+                              "value for pypyraws.steps.ecswaitprep.")
 
 
 def test_waitprep_awsclientout_no_matches():
@@ -33,10 +31,10 @@ def test_waitprep_awsclientout_no_matches():
         context = Context({'awsClientOut': {}})
         prepstep.run_step(context)
 
-    assert repr(err.value) == (
-        "KeyNotInContextError(\"Run ecswaitprep after an ecs method that "
+    assert str(err.value) == (
+        "Run ecswaitprep after an ecs method that "
         "does something with services or tasks. Couldn't find service, "
-        "serviceArns, services, task, taskArns or tasks in awsClientOut.\",)")
+        "serviceArns, services, task, taskArns or tasks in awsClientOut.")
 
 # ------------------------------ tasks ---------------------------------------#
 

--- a/tests/unit/pypyraws/steps/wait_test.py
+++ b/tests/unit/pypyraws/steps/wait_test.py
@@ -15,9 +15,7 @@ def test_aws_wait_missing_awswaitin():
     with pytest.raises(KeyNotInContextError) as err_info:
         wait.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'awsWaitIn not found in the pypyr "
-        "context.',)")
+    assert str(err_info.value) == "awsWaitIn not found in the pypyr context."
 
 
 @patch('pypyraws.aws.service.waiter')
@@ -309,9 +307,7 @@ def test_get_waiter_args_missing_awswaitin():
         client_in, service_name, waiter_name = wait.get_waiter_args(
             context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\'awsWaitIn not found in the pypyr "
-        "context.',)")
+    assert str(err_info.value) == "awsWaitIn not found in the pypyr context."
 
 
 def test_get_waiter_args_missing_servicename():
@@ -327,9 +323,8 @@ def test_get_waiter_args_missing_servicename():
         client_in, service_name, waiter_name = wait.get_waiter_args(
             context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"awsWaitIn missing required key for "
-        "pypyraws.steps.wait: 'serviceName'\",)")
+    assert str(err_info.value) == ("awsWaitIn missing required key for "
+                                   "pypyraws.steps.wait: 'serviceName'")
 
 
 def test_get_waiter_args_missing_waitername():
@@ -345,9 +340,8 @@ def test_get_waiter_args_missing_waitername():
         client_in, service_name, waiter_name = wait.get_waiter_args(
             context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"awsWaitIn missing required key for "
-        "pypyraws.steps.wait: 'waiterName'\",)")
+    assert str(err_info.value) == ("awsWaitIn missing required key for "
+                                   "pypyraws.steps.wait: 'waiterName'")
 
 
 def test_get_waiter_args_servicename_empty():
@@ -364,9 +358,8 @@ def test_get_waiter_args_servicename_empty():
         client_in, service_name, waiter_name = wait.get_waiter_args(
             context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError('serviceName required in awsWaitIn "
-        "for pypyraws.steps.wait',)")
+    assert str(err_info.value) == ("serviceName required in awsWaitIn "
+                                   "for pypyraws.steps.wait")
 
 
 def test_get_waiter_args_waitername_empty():
@@ -383,8 +376,7 @@ def test_get_waiter_args_waitername_empty():
         client_in, service_name, waiter_name = wait.get_waiter_args(
             context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError('waiterName required in awsWaitIn "
-        "for pypyraws.steps.wait',)")
+    assert str(err_info.value) == ("waiterName required in awsWaitIn "
+                                   "for pypyraws.steps.wait")
 
 # ---------------------------- get_waiter_args------------------------------#

--- a/tests/unit/pypyraws/steps/waitfor_test.py
+++ b/tests/unit/pypyraws/steps/waitfor_test.py
@@ -17,9 +17,9 @@ def test_waitfor_missing_awswaitfor():
     with pytest.raises(KeyNotInContextError) as err_info:
         waitfor_step.run_step(context)
 
-    assert repr(err_info.value) == (
-        'KeyNotInContextError("context[\'awsWaitFor\'] doesn\'t exist. It '
-        'must exist for pypyraws.steps.waitfor.",)')
+    assert str(err_info.value) == (
+        "context[\'awsWaitFor\'] doesn\'t exist. It "
+        "must exist for pypyraws.steps.waitfor.")
 
 
 @patch('pypyraws.aws.service.operation_exec', return_value={'rk1': 'rv1',
@@ -87,9 +87,8 @@ def test_waitfor_fail_no_client_args(mock_sleep, mock_service):
         with patch.object(logger, 'error') as mock_logger_error:
             waitfor_step.run_step(context)
 
-    assert repr(err_info.value) == ("WaitTimeOut('aws service name "
-                                    "method_name did not return xxx within "
-                                    "10 retries.',)")
+    assert str(err_info.value) == ("aws service name method_name did not "
+                                   "return xxx within 10 retries.")
 
     mock_logger_error.assert_called_once_with(
         'aws service name method_name did not return xxx within 10. '
@@ -132,7 +131,7 @@ def test_waitfor_fail_no_client_args_no_throw(mock_sleep, mock_service):
         }})
 
     logger = logging.getLogger('pypyraws.steps.waitfor')
-    with patch.object(logger, 'warn') as mock_logger_warn:
+    with patch.object(logger, 'warning') as mock_logger_warn:
         waitfor_step.run_step(context)
 
     mock_logger_warn.assert_called_once_with(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36,py37
 skipsdist = false
 
 [testenv:dev]


### PR DESCRIPTION
- make unit tests compatible with py 3.7. This is really just one change because of this https://bugs.python.org/issue30399 In a nutshell, repr() on Exceptions used to return an extra comma at the end in <py3.7, it doesn't anymore.
- ci will run both 3.6 and 3.7 unit tests
- logger.warn deprecated, replace with .warning
- README updates with contributing guide