### PR TITLE
shippable only deploy on py3.7 matrix

### DIFF
--- a/shippable.yaml
+++ b/shippable.yaml
@@ -14,10 +14,10 @@ build:
     # tox ci flakes, tests and covs.
     - tox -e ci -- --cov=pypyraws --cov-report xml:shippable/codecoverage/coverage.xml --junitxml=shippable/testresults/junitresults.xml tests
     # all checks cleared on master and this is a merge commit (branch is protected and not in the midst of a PR), tag for release.
-    - if [ "$IS_PULL_REQUEST" == false ] && [ "$BRANCH" == "master" ] ; then ./ops/shippable-tag-release.sh; fi
+    - if [ "$IS_PULL_REQUEST" == false ] && [ "$SHIPPABLE_PYTHON_VERSION" == "3.7" ] && [ "$BRANCH" == "master" ] ; then ./ops/shippable-tag-release.sh; fi
 
   on_success:
-    - if [ "$IS_RELEASE" = "true" ]; then ./ops/shippable-pypi-release.sh; fi;
+    - if [ "$IS_RELEASE" == "true" ] && [ "$SHIPPABLE_PYTHON_VERSION" == "3.7" ] ; then ./ops/shippable-pypi-release.sh; fi;
 
 integrations:
   key:


### PR DESCRIPTION
- no functional change. only deploy to pypi on py3.7 matrix build in shippable