### PR TITLE
s3fetch steps save to specified key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -305,9 +305,10 @@ Required input context is:
     methodArgs:
       Bucket: '{bucket}'
       Key: arb.yaml
+    outKey: 'destination pypyr context key' # optional
 
-- clientArgs are passed to the aws s3 client constructor. These are optional.
-- methodArgs are passed the the s3 ``get_object`` call. The minimum required
+- *clientArgs* are passed to the aws s3 client constructor. These are optional.
+- *methodArgs* are passed the the s3 ``get_object`` call. The minimum required
   values are:
 
   - Bucket
@@ -315,6 +316,8 @@ Required input context is:
 
 - Check here for all available arguments (including SSE server-side encryption):
   http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_object
+- *outKey* writes fetched yaml to this context key. If not specified, yaml
+  writes directly to context root.
 
 The *s3Fetch* context supports text `Substitutions`_.
 
@@ -330,9 +333,8 @@ I.e if file yaml has
 but context ``{'eggs': 'fried'}`` already exists, returned ``context['eggs']``
 will be 'boiled'.
 
-The yaml should not be a list at the top level, but rather a mapping.
-
-So the top-level yaml should not look like this:
+If *outKey* is not specified, the yaml should not be a list at the top level,
+but rather a mapping. So the top-level yaml should not look like this:
 
 .. code-block:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -141,8 +141,7 @@ not update, the code already will dynamically use new features and services on
 the boto3 client.
 
 pypyr context
-----------------
-
+-------------
 Requires the following context items:
 
 .. code-block:: yaml
@@ -158,6 +157,11 @@ Requires the following context items:
       arg2Name: arg2Value
 
 The *awsClientIn* context supports text `Substitutions`_.
+
+AWS response
+------------
+After this step completes the full response is available to subsequent steps
+in the pypyr context in the *awsClientOut* key.
 
 Sample pipeline
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -263,9 +263,10 @@ Required input context is:
     methodArgs:
       Bucket: '{bucket}'
       Key: arb.json
+    outKey: 'destination pypyr context key' # optional
 
-- clientArgs are passed to the aws s3 client constructor. These are optional.
-- methodArgs are passed the the s3 ``get_object`` call. The minimum required
+- *clientArgs* are passed to the aws s3 client constructor. These are optional.
+- *methodArgs* are passed the the s3 ``get_object`` call. The minimum required
   values are:
 
   - Bucket
@@ -273,6 +274,8 @@ Required input context is:
 
 - Check here for all available arguments (including SSE server-side encryption):
   http://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.get_object
+- *outKey* writes fetched json to this context key. If not specified, json
+  writes directly to context root.
 
 Json parsed from the file will be merged into the pypyr context. This will
 overwrite existing values if the same keys are already in there.
@@ -280,9 +283,10 @@ overwrite existing values if the same keys are already in there.
 I.e if file json has ``{'eggs' : 'boiled'}``, but context ``{'eggs': 'fried'}``
 already exists, returned ``context['eggs']`` will be 'boiled'.
 
-The json should not be an array [] at the top level, but rather an Object.
+If *outKey* is not specified, the json should not be an Array [] at the root
+level, but rather an Object {}.
 
-The *s3Fetch* context supports text `Substitutions`_.
+The *s3Fetch* input context supports text `Substitutions`_.
 
 See a worked example for `pypyr aws s3fetch here
 <https://github.com/pypyr/pypyr-example/blob/master/pipelines/aws-s3fetch.yaml>`__.

--- a/pypyraws/steps/s3fetchyaml.py
+++ b/pypyraws/steps/s3fetchyaml.py
@@ -1,4 +1,5 @@
-"""pypyr step to fetch a json file from s3 and put it in context."""
+"""pypyr step to fetch a yaml file from s3 and put it in context."""
+from collections.abc import MutableMapping
 import logging
 import pypyraws.aws.s3
 import ruamel.yaml as yaml
@@ -8,17 +9,19 @@ logger = logging.getLogger(__name__)
 
 
 def run_step(context):
-    """Fetch a json file from s3 and put the json values into context.
+    """Fetch a yaml file from s3 and put the yaml values into context.
 
     Args:
         - context: pypyr.context.Context. Mandatory. Should contain keys for:
             - s3Fetch: dict. mandatory. Must contain:
                 - Bucket: string. s3 bucket name.
                 - Key: string. s3 key name.
+            - outKey. string. If exists, write yaml structure to this
+                           context key. Else yaml writes to context root.
 
-    json parsed from the s3 file will be merged into the
+    yaml parsed from the s3 file will be merged into the
     context. This will overwrite existing values if the same keys are already
-    in there. I.e if s3 json has {'eggs' : 'boiled'} and context
+    in there. I.e if s3 yaml has {'eggs' : 'boiled'} and context
     {'eggs': 'fried'} already exists, returned context['eggs'] will be
     'boiled'.
     """
@@ -28,7 +31,23 @@ def run_step(context):
     yaml_loader = yaml.YAML(typ='safe', pure=True)
     payload = yaml_loader.load(response)
     logger.debug("successfully parsed yaml from s3 response bytes")
-    context.update(payload)
+
+    destination_key_expression = context['s3Fetch'].get('outKey', None)
+
+    if destination_key_expression:
+        destination_key = context.get_formatted_iterable(
+            destination_key_expression)
+        logger.debug(f"Writing yaml to context {destination_key}")
+        context[destination_key] = payload
+    else:
+        if not isinstance(payload, MutableMapping):
+            raise TypeError(
+                "yaml input should describe a dictionary at the top "
+                "level when outKey isn't specified. You should have "
+                "something like \n'key1: value1'\n key2: value2'\n"
+                "in the yaml top-level, not \n'- value1\n - value2'")
+        context.update(payload)
+
     logger.info("loaded s3 yaml into pypyr context")
 
     logger.debug("done")

--- a/pypyraws/version.py
+++ b/pypyraws/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0
+current_version = 1.1.0
 
 [bdist_wheel]
 universal = 0

--- a/tests/unit/pypyraws/steps/s3fetchjson_test.py
+++ b/tests/unit/pypyraws/steps/s3fetchjson_test.py
@@ -1,8 +1,9 @@
 """s3fetchjson.py unit tests."""
 import json
+import pytest
+from unittest.mock import Mock, patch
 import pypyraws.steps.s3fetchjson as s3fetchjson
 from pypyr.context import Context
-from unittest.mock import Mock, patch
 
 
 @patch('pypyraws.aws.service.operation_exec')
@@ -31,3 +32,124 @@ def test_s3fetchjson(mock_s3):
     assert context['k1'] == 'v1'
     assert context['newkey'] == 'newvalue'
     assert context['newkey2'] == 'newvalue2'
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_with_destination(mock_s3):
+    """Json writes to destination key."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps([1, 2, 3]), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 'writehere'
+        }})
+
+    s3fetchjson.run_step(context)
+
+    assert context['writehere'] == [1, 2, 3]
+    assert len(context) == 3
+    assert context == {
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 'writehere'},
+        'writehere': [1, 2, 3]
+    }
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_with_destination_int(mock_s3):
+    """Json overwrites destination key that's not a string."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps([1, 2, 3]), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 99},
+        99: 'blah'
+    })
+
+    s3fetchjson.run_step(context)
+
+    assert context[99] == [1, 2, 3]
+    assert len(context) == 3
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_with_destination_formatting(mock_s3):
+    """Json writes to destination key found by formatting expression."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps({'1': 2, '2': 3}), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3]},
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': '{keyhere[sub][0]}'},
+    })
+
+    s3fetchjson.run_step(context)
+
+    assert len(context) == 3
+    assert context['outkey'] == {'1': 2, '2': 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
+    assert context['s3Fetch'] == {
+        'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+        'methodArgs': {'Bucket': 'bucket name',
+                       'Key': 'key name',
+                       'SSECustomerAlgorithm': 'sse alg',
+                       'SSECustomerKey': 'sse key'},
+        'outKey': '{keyhere[sub][0]}'}
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_list_fails(mock_s3):
+    """Json describing a list rather than a dict should fail if no outkey."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps([1, 2, 3]), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'}
+        }})
+
+    with pytest.raises(TypeError):
+        s3fetchjson.run_step(context)

--- a/tests/unit/pypyraws/steps/s3fetchyaml_test.py
+++ b/tests/unit/pypyraws/steps/s3fetchyaml_test.py
@@ -1,5 +1,6 @@
 """s3fetchyaml.py unit tests."""
 import io
+import pytest
 import pypyraws.steps.s3fetchyaml  # as s3fetchyaml
 from pypyr.context import Context
 import ruamel.yaml as yaml
@@ -31,3 +32,124 @@ def test_s3fetchyaml(mock_s3):
     assert context['k1'] == 'v1'
     assert context['newkey'] == 'newvalue'
     assert context['newkey2'] == 'newvalue2'
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_s3fetchyaml_with_destination(mock_s3):
+    """Yaml writes to destination key."""
+    input = [1, 2, 3]
+    yaml_loader = yaml.YAML()
+    string_stream = io.StringIO()
+    yaml_loader.dump(input, string_stream)
+    mock_s3.side_effect = [{'Body': string_stream.getvalue()}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 'writehere'
+        }})
+
+    pypyraws.steps.s3fetchyaml.run_step(context)
+
+    assert context['writehere'] == [1, 2, 3]
+    assert len(context) == 3
+    assert context == {
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 'writehere'},
+        'writehere': [1, 2, 3]
+    }
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_s3fetchyaml_with_destination_int(mock_s3):
+    """Yaml overwrites destination key that's not a string."""
+    input = [1, 2, 3]
+    yaml_loader = yaml.YAML()
+    string_stream = io.StringIO()
+    yaml_loader.dump(input, string_stream)
+    mock_s3.side_effect = [{'Body': string_stream.getvalue()}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': 99},
+        99: 'blah'
+    })
+
+    pypyraws.steps.s3fetchyaml.run_step(context)
+
+    assert context[99] == [1, 2, 3]
+    assert len(context) == 3
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_s3fetchyaml_with_destination_formatting(mock_s3):
+    """Yaml writes to destination key found by formatting expression."""
+    input = {'1': 2, '2': 3}
+    yaml_loader = yaml.YAML()
+    string_stream = io.StringIO()
+    yaml_loader.dump(input, string_stream)
+    mock_s3.side_effect = [{'Body': string_stream.getvalue()}]
+
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3]},
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'outKey': '{keyhere[sub][0]}'},
+    })
+
+    pypyraws.steps.s3fetchyaml.run_step(context)
+
+    assert len(context) == 3
+    assert context['outkey'] == {'1': 2, '2': 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
+    assert context['s3Fetch'] == {
+        'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+        'methodArgs': {'Bucket': 'bucket name',
+                       'Key': 'key name',
+                       'SSECustomerAlgorithm': 'sse alg',
+                       'SSECustomerKey': 'sse key'},
+        'outKey': '{keyhere[sub][0]}'}
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_s3fetchyaml_list_fails(mock_s3):
+    """Yaml describing a list rather than a dict should fail if no outkey."""
+    input = [1, 2, 3]
+    yaml_loader = yaml.YAML()
+    string_stream = io.StringIO()
+    yaml_loader.dump(input, string_stream)
+    mock_s3.side_effect = [{'Body': string_stream.getvalue()}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'}
+        }})
+
+    with pytest.raises(TypeError):
+        pypyraws.steps.s3fetchyaml.run_step(context)

--- a/tox.ini
+++ b/tox.ini
@@ -43,5 +43,5 @@ commands =
 usedevelop = true
 
 [flake8]
-exclude = .tox,*.egg,build,data,dist,.cache
+exclude = .tox,*.egg,build,data,dist,.cache,.deployenv
 select = E,W,F


### PR DESCRIPTION
- document awsClientOut response
- s3fetchjson can save to a specified pypyr context key
- s3fetchyaml can save to a specified pypyr context key
- exclude .deployenv Virtualenv from flake because it wrongly tries to validate external dependencies
- version bump