### PR TITLE
pypyr 4.2.0 compatibility - get_formatted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.py diff=python

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -17,7 +17,7 @@ jobs:
       # You can use PyPy versions in python-version.
       # For example, pypy2 and pypy3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/pypyraws/contextargs.py
+++ b/pypyraws/contextargs.py
@@ -2,16 +2,18 @@
 from pypyr.errors import KeyInContextHasNoValueError, KeyNotInContextError
 
 
-def get_awsclient_args(context, calling_module_name):
+def get_awsclient_args(input_dict, calling_module_name):
     """Get required args from context for awsClientIn type steps.
 
+    Doesn't do any formatting. You gotta format before you get here.
+
     Args:
-        context: pypyr.context.Context.
+        input_dict (dict): dict-like structure containing awsClientIn key.
         calling_module_name: string. This is just to make a friendly error msg
                              should something go wrong.
 
     Returns:
-        tuple(client_in, service_name, method_name)
+        tuple(service_name, method_name, client_args, method_args)
 
     Raises:
         pypyr.errors.KeyNotInContextError: Required key missing in context.
@@ -19,9 +21,8 @@ def get_awsclient_args(context, calling_module_name):
                                                   empty or None.
     """
     try:
-        client_in = context['awsClientIn']
-        service_name = client_in['serviceName']
-        method_name = client_in['methodName']
+        service_name = input_dict['serviceName']
+        method_name = input_dict['methodName']
     except KeyError as err:
         raise KeyNotInContextError(
             f"awsClientIn missing required key for {calling_module_name}: "
@@ -36,24 +37,7 @@ def get_awsclient_args(context, calling_module_name):
         raise KeyInContextHasNoValueError(
             f'methodName required in awsClientIn for {calling_module_name}')
 
-    return client_in, service_name, method_name
+    client_args = input_dict.get('clientArgs', None)
+    method_args = input_dict.get('methodArgs', None)
 
-
-def get_formatted_iterable(input_dict, field_name, context):
-    """Format inputdict's field_name field against context.
-
-    Args:
-        input_dict: dict. Dictionary containing dict to format.
-        field_name: str. Points at field in input_dict to format.
-        context: pypyr.context.Context. Substitutes string expressions from
-                 this.
-
-    Returns:
-        dict: Formatted dictionary that was at input_dict['field_name']
-              Returns None if input_dict['field_name'] doesn't exist.
-    """
-    output = input_dict.get(field_name, None)
-    if output is not None:
-        output = context.get_formatted_iterable(output)
-
-    return output
+    return service_name, method_name, client_args, method_args

--- a/pypyraws/steps/client.py
+++ b/pypyraws/steps/client.py
@@ -41,20 +41,17 @@ def run_step(context):
                                                   None.
     """
     logger.debug("started")
-    client_in, service_name, method_name = contextargs.get_awsclient_args(
-        context, __name__)
+    context.assert_key_has_value('awsClientIn', __name__)
+    client_in = context.get_formatted('awsClientIn')
 
-    client_args = contextargs.get_formatted_iterable(input_dict=client_in,
-                                                     field_name='clientArgs',
-                                                     context=context)
-
-    method_args = contextargs.get_formatted_iterable(input_dict=client_in,
-                                                     field_name='methodArgs',
-                                                     context=context)
+    (service_name,
+     method_name,
+     client_args,
+     method_args) = contextargs.get_awsclient_args(client_in, __name__)
 
     context['awsClientOut'] = pypyraws.aws.service.operation_exec(
-        service_name=context.get_formatted_string(service_name),
-        method_name=context.get_formatted_string(method_name),
+        service_name=service_name,
+        method_name=method_name,
         client_args=client_args,
         operation_args=method_args)
 

--- a/pypyraws/steps/wait.py
+++ b/pypyraws/steps/wait.py
@@ -45,15 +45,8 @@ def run_step(context):
     client_in, service_name, waiter_name = get_waiter_args(context)
 
     waiter_args = client_in.get('waiterArgs', None)
-    if waiter_args is not None:
-        waiter_args = context.get_formatted_iterable(waiter_args)
 
     wait_args = client_in.get('waitArgs', None)
-    if wait_args is not None:
-        wait_args = context.get_formatted_iterable(wait_args)
-
-    waiter_name = context.get_formatted_string(waiter_name)
-    service_name = context.get_formatted_string(service_name)
 
     logger.info(f"Waiting for {waiter_name} on aws {service_name}.")
 
@@ -80,8 +73,9 @@ def get_waiter_args(context):
         pypyr.errors.KeyInContextHasNoValueError: Required key exists but is
                                                   empty or None.
     """
+    context.assert_key_has_value(key='awsWaitIn', caller=__name__)
+    client_in = context.get_formatted('awsWaitIn')
     try:
-        client_in = context['awsWaitIn']
         service_name = client_in['serviceName']
         waiter_name = client_in['waiterName']
     except KeyError as err:

--- a/pypyraws/steps/waitfor.py
+++ b/pypyraws/steps/waitfor.py
@@ -1,5 +1,6 @@
 """pypyr step that creates a custom waiter for any aws client operation."""
 import logging
+from pypyr.utils.asserts import assert_key_has_value
 from pypyr.utils.poll import wait_until_true
 import pypyraws.aws.service
 import pypyraws.contextargs as contextargs
@@ -61,19 +62,13 @@ def run_step(context):
     context.assert_key_has_value('awsWaitFor', __name__)
     wait_for = context['awsWaitFor']
 
-    client_in, service_name, method_name = contextargs.get_awsclient_args(
-        wait_for, __name__)
+    assert_key_has_value(wait_for, 'awsClientIn', __name__, 'awsWaitFor')
+    aws_client_in = context.get_formatted_value(wait_for['awsClientIn'])
 
-    service_name = context.get_formatted_string(service_name)
-    method_name = context.get_formatted_string(method_name)
-
-    client_args = contextargs.get_formatted_iterable(input_dict=client_in,
-                                                     field_name='clientArgs',
-                                                     context=context)
-
-    method_args = contextargs.get_formatted_iterable(input_dict=client_in,
-                                                     field_name='methodArgs',
-                                                     context=context)
+    (service_name,
+     method_name,
+     client_args,
+     method_args) = contextargs.get_awsclient_args(aws_client_in, __name__)
 
     (wait_for_field,
      to_be,
@@ -169,7 +164,7 @@ def get_poll_args(waitfor_dict, context):
     logger.debug("started")
     wait_for_field = waitfor_dict['waitForField']
 
-    to_be = context.get_formatted_string(str(waitfor_dict['toBe']))
+    to_be = context.get_formatted_value(waitfor_dict['toBe'])
 
     poll_interval = context.get_formatted_as_type(
         waitfor_dict.get('pollInterval', 30),

--- a/pypyraws/version.py
+++ b/pypyraws/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.1.2'
+__version__ = '1.2.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.2
+current_version = 1.2.0
 
 [bumpversion:file:pypyraws/version.py]
 

--- a/tests/unit/pypyraws/aws/s3_test.py
+++ b/tests/unit/pypyraws/aws/s3_test.py
@@ -8,20 +8,20 @@ from unittest.mock import patch
 # ---------------------------- get_payload ----------------------------------#
 
 
-def test_get_payload_no_s3fetch():
-    """Operation exec with s3Fetch raises."""
+def test_get_fetch_input_no_s3fetch():
+    """Operation exec with no s3Fetch raises."""
     context = Context({'k1': 'v1'})
     with pytest.raises(KeyNotInContextError) as err_info:
-        ps3.get_payload(context)
+        ps3.get_fetch_input(context, 'arb')
 
-    assert str(err_info.value) == ("s3Fetch not found in the pypyr context.")
+    assert str(err_info.value) == (
+        "context['s3Fetch'] doesn't exist. It must exist for arb.")
 
 
 def test_get_payload_no_methodargs():
     """Operation exec with s3Fetch raises."""
-    context = Context({'s3Fetch': {'k1': 'v1'}})
     with pytest.raises(KeyNotInContextError) as err_info:
-        ps3.get_payload(context)
+        ps3.get_payload({'s3Fetch': {'k1': 'v1'}})
 
     assert str(err_info.value) == ("s3Fetch missing required key for "
                                    "pypyraws.steps.s3fetch step: methodArgs")
@@ -43,7 +43,7 @@ def test_aws_client_pass(mock_s3):
                            'SSECustomerAlgorithm': 'sse alg',
                            'SSECustomerKey': 'sse key'}
         }})
-    payload = ps3.get_payload(context)
+    payload = ps3.get_payload(context['s3Fetch'])
 
     assert payload
     assert payload == b'bunchofbytes'
@@ -86,7 +86,7 @@ def test_aws_client_pass_no_client_args(mock_s3):
                            'SSECustomerAlgorithm': 'sse alg',
                            'SSECustomerKey': 'sse key'}
         }})
-    payload = ps3.get_payload(context)
+    payload = ps3.get_payload(context['s3Fetch'])
 
     assert payload
     assert payload == b'bunchofbytes'
@@ -131,7 +131,8 @@ def test_aws_client_pass_substitutions(mock_s3):
                            'SSECustomerAlgorithm': 'sse alg',
                            'SSECustomerKey': 'sse key'}
         }})
-    payload = ps3.get_payload(context)
+
+    payload = ps3.get_payload(ps3.get_fetch_input(context, 'arbcaller'))
 
     assert payload
     assert payload == b'bunchofbytes'

--- a/tests/unit/pypyraws/contextargs_test.py
+++ b/tests/unit/pypyraws/contextargs_test.py
@@ -16,29 +16,16 @@ def test_get_awsclient_args_pass():
             'methodName': 'method_name',
             'arbKey': 'arb_value'
         }})
-    client_in, service_name, method_name = contextargs.get_awsclient_args(
-        context, 'pypyraws.steps.client')
+    (service_name,
+     method_name,
+     client_args,
+     method_args) = contextargs.get_awsclient_args(context['awsClientIn'],
+                                                   'pypyraws.steps.client')
 
-    assert client_in == {
-        'serviceName': 'service name',
-        'methodName': 'method_name',
-        'arbKey': 'arb_value'
-    }
     assert service_name == 'service name'
     assert method_name == 'method_name'
-
-
-def test_get_awsclient_args_missing_awsclientin():
-    """Missing awsClientIn raises."""
-    context = Context({'k1': 'v1'})
-
-    with pytest.raises(KeyNotInContextError) as err_info:
-        client_in, service_name, method_name = contextargs.get_awsclient_args(
-            context, 'pypyraws.steps.client')
-
-    assert str(err_info.value) == (
-        "awsClientIn missing required key for "
-        "pypyraws.steps.client: awsClientIn not found in the pypyr context.")
+    assert client_args is None
+    assert method_args is None
 
 
 def test_get_awsclient_args_missing_servicename():
@@ -51,8 +38,8 @@ def test_get_awsclient_args_missing_servicename():
         }})
 
     with pytest.raises(KeyNotInContextError) as err_info:
-        client_in, service_name, method_name = contextargs.get_awsclient_args(
-            context, 'pypyraws.steps.client')
+        contextargs.get_awsclient_args(context['awsClientIn'],
+                                       'pypyraws.steps.client')
 
     assert str(err_info.value) == ("awsClientIn missing required key for "
                                    "pypyraws.steps.client: 'serviceName'")
@@ -68,8 +55,8 @@ def test_get_awsclient_args_missing_methodname():
         }})
 
     with pytest.raises(KeyNotInContextError) as err_info:
-        client_in, service_name, method_name = contextargs.get_awsclient_args(
-            context, 'pypyraws.steps.client')
+        contextargs.get_awsclient_args(context['awsClientIn'],
+                                       'pypyraws.steps.client')
 
     assert str(err_info.value) == ("awsClientIn missing required key for "
                                    "pypyraws.steps.client: 'methodName'")
@@ -86,8 +73,8 @@ def test_get_awsclient_args_servicename_empty():
         }})
 
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
-        client_in, service_name, method_name = contextargs.get_awsclient_args(
-            context, 'pypyraws.steps.client')
+        contextargs.get_awsclient_args(context['awsClientIn'],
+                                       'pypyraws.steps.client')
 
     assert str(err_info.value) == ("serviceName required in awsClientIn "
                                    "for pypyraws.steps.client")
@@ -104,65 +91,10 @@ def test_get_awsclient_args_methodname_empty():
         }})
 
     with pytest.raises(KeyInContextHasNoValueError) as err_info:
-        client_in, service_name, method_name = contextargs.get_awsclient_args(
-            context, 'pypyraws.steps.client')
+        contextargs.get_awsclient_args(context['awsClientIn'],
+                                       'pypyraws.steps.client')
 
     assert str(err_info.value) == ("methodName required in awsClientIn "
                                    "for pypyraws.steps.client")
 
 # ---------------------------- get_awsclient_args-----------------------------#
-
-# ---------------------------- get_formatted_iterable-------------------------#
-
-
-def test_getformatted_iterable_pass():
-    """get_formatted_iterable passes."""
-    context = Context({
-        'k1': 'v1',
-        'k2': 'v2',
-        'awsClientIn': {
-            'serviceName': '',
-            'methodName': 'method_name',
-            'clientArgs': {
-                'cak1': 'cak2',
-                '{k1}': '{k2}'
-            },
-            'arbKey': 'arb_value'
-
-        }})
-
-    result = contextargs.get_formatted_iterable(
-        input_dict=context['awsClientIn'],
-        field_name='clientArgs',
-        context=context)
-
-    assert result == {
-        'cak1': 'cak2',
-        'v1': 'v2'
-    }
-
-
-def test_getformatted_iterable_none_pass():
-    """get_formatted_iterable none returns none."""
-    context = Context({
-        'k1': 'v1',
-        'k2': 'v2',
-        'awsClientIn': {
-            'serviceName': '',
-            'methodName': 'method_name',
-            'clientArgs': {
-                'cak1': 'cak2',
-                '{k1}': '{k2}'
-            },
-            'arbKey': 'arb_value'
-
-        }})
-
-    result = contextargs.get_formatted_iterable(
-        input_dict=context['awsClientIn'],
-        field_name='doesntexist',
-        context=context)
-
-    assert result is None
-
-# ---------------------------- get_formatted_iterable-------------------------#

--- a/tests/unit/pypyraws/steps/client_test.py
+++ b/tests/unit/pypyraws/steps/client_test.py
@@ -16,8 +16,8 @@ def test_aws_client_missing_awsclientin():
         client_step.run_step(context)
 
     assert str(err_info.value) == (
-        "awsClientIn missing required key for pypyraws.steps.client: "
-        "awsClientIn not found in the pypyr context.")
+        "context['awsClientIn'] doesn't exist. It must exist for "
+        "pypyraws.steps.client.")
 
 
 @patch('pypyraws.aws.service.operation_exec', return_value={'rk1': 'rv1',

--- a/tests/unit/pypyraws/steps/s3fetchjson_test.py
+++ b/tests/unit/pypyraws/steps/s3fetchjson_test.py
@@ -51,7 +51,7 @@ def test_fetchjson_with_destination(mock_s3):
                            'Key': 'key name',
                            'SSECustomerAlgorithm': 'sse alg',
                            'SSECustomerKey': 'sse key'},
-            'outKey': 'writehere'
+            'key': 'writehere'
         }})
 
     s3fetchjson.run_step(context)
@@ -66,7 +66,7 @@ def test_fetchjson_with_destination(mock_s3):
                            'Key': 'key name',
                            'SSECustomerAlgorithm': 'sse alg',
                            'SSECustomerKey': 'sse key'},
-            'outKey': 'writehere'},
+            'key': 'writehere'},
         'writehere': [1, 2, 3]
     }
 
@@ -74,6 +74,33 @@ def test_fetchjson_with_destination(mock_s3):
 @patch('pypyraws.aws.service.operation_exec')
 def test_fetchjson_with_destination_int(mock_s3):
     """Json overwrites destination key that's not a string."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps([1, 2, 3]), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'k1': 'v1',
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'key': 99},
+        99: 'blah'
+    })
+
+    s3fetchjson.run_step(context)
+
+    assert context[99] == [1, 2, 3]
+    assert len(context) == 3
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_with_destination_int_old(mock_s3):
+    """Test outKey still works for backwards compatibility."""
     mock_body = Mock()
     bunch_of_bytes = bytes(json.dumps([1, 2, 3]), 'utf-8')
 
@@ -99,8 +126,8 @@ def test_fetchjson_with_destination_int(mock_s3):
 
 
 @patch('pypyraws.aws.service.operation_exec')
-def test_fetchjson_with_destination_formatting(mock_s3):
-    """Json writes to destination key found by formatting expression."""
+def test_fetchjson_with_destination_formatting_old(mock_s3):
+    """Test deprecated outKey still works for backwards compatibility."""
     mock_body = Mock()
     bunch_of_bytes = bytes(json.dumps({'1': 2, '2': 3}), 'utf-8')
 
@@ -130,6 +157,40 @@ def test_fetchjson_with_destination_formatting(mock_s3):
                        'SSECustomerAlgorithm': 'sse alg',
                        'SSECustomerKey': 'sse key'},
         'outKey': '{keyhere[sub][0]}'}
+
+
+@patch('pypyraws.aws.service.operation_exec')
+def test_fetchjson_with_destination_formatting(mock_s3):
+    """Json writes to destination key found by formatting expression."""
+    mock_body = Mock()
+    bunch_of_bytes = bytes(json.dumps({'1': 2, '2': 3}), 'utf-8')
+
+    mock_body.read.return_value = bunch_of_bytes
+    mock_s3.side_effect = [{'Body': mock_body}]
+
+    context = Context({
+        'keyhere': {'sub': ['outkey', 2, 3]},
+        's3Fetch': {
+            'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+            'methodArgs': {'Bucket': 'bucket name',
+                           'Key': 'key name',
+                           'SSECustomerAlgorithm': 'sse alg',
+                           'SSECustomerKey': 'sse key'},
+            'key': '{keyhere[sub][0]}'},
+    })
+
+    s3fetchjson.run_step(context)
+
+    assert len(context) == 3
+    assert context['outkey'] == {'1': 2, '2': 3}
+    assert context['keyhere'] == {'sub': ['outkey', 2, 3]}
+    assert context['s3Fetch'] == {
+        'clientArgs': {'ck1': 'cv1', 'ck2': 'cv2'},
+        'methodArgs': {'Bucket': 'bucket name',
+                       'Key': 'key name',
+                       'SSECustomerAlgorithm': 'sse alg',
+                       'SSECustomerKey': 'sse key'},
+        'key': '{keyhere[sub][0]}'}
 
 
 @patch('pypyraws.aws.service.operation_exec')

--- a/tests/unit/pypyraws/steps/wait_test.py
+++ b/tests/unit/pypyraws/steps/wait_test.py
@@ -16,8 +16,8 @@ def test_aws_wait_missing_awswaitin():
         wait.run_step(context)
 
     assert str(err_info.value) == (
-        "awsWaitIn missing required key for pypyraws.steps.wait: "
-        "awsWaitIn not found in the pypyr context.")
+        "context['awsWaitIn'] doesn't exist. It must exist for "
+        "pypyraws.steps.wait.")
 
 
 @patch('pypyraws.aws.service.waiter')
@@ -310,8 +310,8 @@ def test_get_waiter_args_missing_awswaitin():
             context)
 
     assert str(err_info.value) == (
-        "awsWaitIn missing required key for pypyraws.steps.wait: "
-        "awsWaitIn not found in the pypyr context.")
+        "context['awsWaitIn'] doesn't exist. It must exist for "
+        "pypyraws.steps.wait.")
 
 
 def test_get_waiter_args_missing_servicename():


### PR DESCRIPTION
- retire deprecated `get_formatted_iterable` and `get_formatted_string` in favour of `get_formatted_value`. This is for pypyr 4.2.0 compatibility.
