### PR TITLE
fix tagging to work with None

### DIFF
--- a/ops/tag.yaml
+++ b/ops/tag.yaml
@@ -25,7 +25,7 @@ steps:
         save: True
   - name: pypyr.steps.stopstepgroup
     description: --> check if tag already exists
-    run: !py cmdOut['stdout'].rstrip('\r\n') == f'v{version}'
+    run: !py cmdOut['stdout'] == f'v{version}'
   - name: pypyr.steps.cmd
     comment: tag current HEAD
     description: --> create new tag for release


### PR DESCRIPTION
- bug where stdout is None raises error. Stripping happens in `pypyr.steps.cmd` in pypyr 4.2.0