### PR TITLE
ops/build work with new py style. remove discord from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ awsWaitFor:
 Don't Panic! Check the 
 [pypyraws technical docs](https://pypyr.io/docs/plugins/aws/) to begin. 
 For help, community & talk, check 
-[pypyr twitter](https://twitter.com/pypyrpipes/), or join the chat on 
-[pypyr discord](https://discordapp.com/invite/8353JkB)!
+[pypyr twitter](https://twitter.com/pypyrpipes/), or join the chat at the 
+[pypyr community discussion forum](https://github.com/pypyr/pypyr/discussions)!
 
 ## contribute
 ### developers

--- a/ops/build.yaml
+++ b/ops/build.yaml
@@ -115,6 +115,7 @@ get_version:
     in:
       defaults:
         isConfigSet: false
+        is_version_module_loaded: False
   - name: pypyr.steps.call
     comment: set default config & environment values only if not already set.
     skip: '{isConfigSet}'
@@ -123,13 +124,16 @@ get_version:
   - name: pypyr.steps.py
     description: --> get version
     in:
-      pycode: |
+      py: |
         import importlib
-        version_module = importlib.import_module(context['version_module_name'])
-        if context.get('is_version_module_loaded'): 
+        version_module = importlib.import_module(version_module_name)
+        if is_version_module_loaded:
           importlib.reload(version_module)
-        context['version'] = f'{version_module.__version__}'
-        context['is_version_module_loaded'] = True
+
+        version = f'{version_module.__version__}'
+        is_version_module_loaded = True
+        
+        save('version', 'is_version_module_loaded')
   - name: pypyr.steps.echo
     in:
       echoMe: version is {version}


### PR DESCRIPTION
- ops/build compatible w the new py style
- discussions moving to GitHub