### PR TITLE
retire py 3.6. add py 3.10

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -17,7 +17,7 @@ jobs:
       # You can use PyPy versions in python-version.
       # For example, pypy2 and pypy3
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/pypyraws/version.py
+++ b/pypyraws/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 
 [bumpversion:file:pypyraws/version.py]
 

--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,10 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
- Retire py 3.6
- Add py 3.10 CI 
- update trove classifiers for pypi