### PR TITLE
update gh action status badge to refer specifically to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sure, you can bash it up, and I do that too, but running it as a pipeline via
 pypyr has actually made my life quite a bit easier because of not having to 
 deal with conditionals, error traps and input validation.
 
-[![build status](https://github.com/pypyr/pypyr-aws/workflows/lint-test-build/badge.svg)](https://github.com/pypyr/pypyr-aws/actions)
+[![build status](https://github.com/pypyr/pypyr-aws/workflows/lint-test-build/badge.svg?branch=main)](https://github.com/pypyr/pypyr-aws/actions)
 [![coverage status](https://codecov.io/gh/pypyr/pypyr-aws/branch/main/graph/badge.svg)](https://codecov.io/gh/pypyr/pypyr-aws)[![pypi version](https://badge.fury.io/py/pypyraws.svg)](https://pypi.python.org/pypi/pypyraws/)
 [![apache 2.0 license](https://img.shields.io/github/license/pypyr/pypyr-aws)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
Adding branch query param means it won't report failure on build warnings on non-main branch.